### PR TITLE
issue(42): Unable to Mock FlutterEasyDialogs in Unit Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 4.0.5
 * **FEAT:** https://github.com/feduke-nukem/flutter_easy_dialogs/issues/40
+* **FEAT:** Made `FlutterEasyDialogs.controller` public API by removing `@visibleForTesting` annotation ([issue 42](https://github.com/feduke-nukem/flutter_easy_dialogs/issues/42))
+
 
 ## 4.0.4
 * **FIX:** Fixed https://github.com/feduke-nukem/flutter_easy_dialogs/issues/37

--- a/lib/src/flutter_easy_dialogs.dart
+++ b/lib/src/flutter_easy_dialogs.dart
@@ -17,7 +17,6 @@ final class FlutterEasyDialogs extends StatelessWidget {
     super.key,
   });
 
-  @visibleForTesting
   static EasyDialogsController get controller =>
       OverlayProvider.stateKey.currentState!.controller;
 


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Removed `@visibleForTesting` annotation from `FlutterEasyDialogs.controller` getter to make it part of the public API.

Previously, the `controller` getter was marked as visible only for testing purposes. This limitation prevented developers from working with the controller directly and made it impossible to mock the controller in tests without accessing the internal singleton through `FlutterEasyDialogs`.

**Changes:**
- Removed `@visibleForTesting` annotation from `FlutterEasyDialogs.controller`
- Updated `CHANGELOG.md` with feature description

Resolves #42

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore