### PR TITLE
issue(45): Make EasyDialogsController publicly accessible and mockable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+## 4.0.6
+* **FIX:** Removed `final` modifier from `EasyDialogsController` class to enable mocking ([issue 45](https://github.com/feduke-nukem/flutter_easy_dialogs/issues/45))
+
 ## 4.0.5
 * **FEAT:** https://github.com/feduke-nukem/flutter_easy_dialogs/issues/40
 * **FEAT:** Made `FlutterEasyDialogs.controller` public API by removing `@visibleForTesting` annotation ([issue 42](https://github.com/feduke-nukem/flutter_easy_dialogs/issues/42))
-
 
 ## 4.0.4
 * **FIX:** Fixed https://github.com/feduke-nukem/flutter_easy_dialogs/issues/37

--- a/lib/src/core/easy_dialogs_controller.dart
+++ b/lib/src/core/easy_dialogs_controller.dart
@@ -20,7 +20,7 @@ part 'easy_dialog_dismiss.dart';
 /// {@category Migration guide from 2.x to 3.x}
 /// {@category Dialogs}
 /// Core class for manipulating dialogs.
-final class EasyDialogsController {
+class EasyDialogsController {
   @visibleForTesting
   final entries = <Object, _DialogEntry>{};
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
 Removed `final` modifier from `EasyDialogsController` class. 
Allows proper mocking and implementing the controller in unit and widget tests

close #45 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore